### PR TITLE
Update timehandler.class.php

### DIFF
--- a/core/timehandler.class.php
+++ b/core/timehandler.class.php
@@ -472,7 +472,7 @@ if (!class_exists("timehandler")){
 				$timezone_ab = DateTimeZone::listAbbreviations();
 				
 				$london = new DateTimeZone('Europe/London');
-				$london_dt = new DateTime('31-12-2012', $london);
+				$london_dt = new DateTime('31-12-2014', $london);
 				foreach($timezone_ab as $key => $more_data) {
 					foreach($more_data as $tz) {
 						$value = $tz['timezone_id'];


### PR DESCRIPTION
Fixed timezone Offset counting.
Example for Europe/Moscow from "GMT +04:00" (wrong) to "GMT +03:00" (right)