### PR TITLE
restore compability with php versions < 5.6

### DIFF
--- a/core/constants.php
+++ b/core/constants.php
@@ -72,47 +72,4 @@ define('EQDKP_CRL_URL',				"https://raw.githubusercontent.com/EQdkpPlus/misc-crl
 define('EQDKP_WIKI_URL',			"http://eqdkp-plus.eu/wiki/");
 define('EQDKP_BUGTRACKER_URL',		"http://eqdkp-plus.eu/bugtracker/");
 
-//Tag Blacklist for filtering article content
-define('TAG_BLACKLIST', array(
-	'applet',
-	'body',
-	'bgsound',
-	'base',
-	'basefont',
-	'frame',
-	'frameset',
-	'head',
-	'html',
-	'id',
-	'ilayer',
-	'layer',
-	'link',
-	'meta',
-	'name',
-	'script',
-	'title',
-	'xml',
-	'iframe',
-));
-
-//Attribute Blacklist for filtering article content
-define('ATTR_BLACKLIST', array(
-	'onclick',
-	"ondblclick",
-	"onkeydown",
-	"onkeypress",
-	"onkeyup",
-	"onmousedown",
-	"onmousemove",
-	"onmouseout",
-	"onmouseover",
-	"onmouseup",
-	"onchange",
-	'action',
-	'background',
-	'codebase',
-	'dynsrc',
-	'lowsrc',
-));
-
 ?>

--- a/core/data_handler/includes/modules/write/article_categories/pdh_w_article_categories.class.php
+++ b/core/data_handler/includes/modules/write/article_categories/pdh_w_article_categories.class.php
@@ -93,12 +93,7 @@ if(!class_exists('pdh_w_article_categories')) {
 			
 			$strDescription = $this->bbcode->replace_shorttags($strDescription);
 			$strDescription = $this->embedly->parseString($strDescription);
-			
-			if(!$this->user->check_auth('u_articles_script', false)){
-				include_once($this->root_path."libraries/inputfilter/input.class.php");
-				$filter = new FilterInput(TAG_BLACKLIST, ATTR_BLACKLIST, 1,1);
-				$strDescription = htmlspecialchars($filter->clean($strDescription));
-			}			
+			$strDescription = $this->filter_string($strDescription);
 			
 			$arrQuery  = array(
 				'name' 			=> $strName,
@@ -158,12 +153,7 @@ if(!class_exists('pdh_w_article_categories')) {
 			
 			$strDescription = $this->bbcode->replace_shorttags($strDescription);
 			$strDescription = $this->embedly->parseString($strDescription);
-			
-			if(!$this->user->check_auth('u_articles_script', false)){
-				include_once($this->root_path."libraries/inputfilter/input.class.php");
-				$filter = new FilterInput(TAG_BLACKLIST, ATTR_BLACKLIST, 1,1);
-				$strDescription = htmlspecialchars($filter->clean($strDescription));
-			}
+			$strDescription = $this->filter_string($strDescription);
 			
 			$arrQuery = array(
 				'name' 			=> $strName,
@@ -249,6 +239,59 @@ if(!class_exists('pdh_w_article_categories')) {
 			$a_satzzeichen = array("\"",",",";",".",":","!","?", "&", "=", "/", "|", "#", "*", "+", "(", ")", "%", "$");
 			$strAlias = str_replace($a_satzzeichen, "", $strAlias);
 			return $strAlias;
+		}
+		
+		private function filter_string($strIn){
+			if(!$this->user->check_auth('u_articles_script', false)){
+				
+				//Tag Blacklist for filtering article content
+				$tag_blacklist = array(
+					'applet',
+					'body',
+					'bgsound',
+					'base',
+					'basefont',
+					'frame',
+					'frameset',
+					'head',
+					'html',
+					'id',
+					'ilayer',
+					'layer',
+					'link',
+					'meta',
+					'name',
+					'script',
+					'title',
+					'xml',
+					'iframe',
+				);
+				
+				//Attribute Blacklist for filtering article content
+				$attr_blacklist = array(
+					'onclick',
+					"ondblclick",
+					"onkeydown",
+					"onkeypress",
+					"onkeyup",
+					"onmousedown",
+					"onmousemove",
+					"onmouseout",
+					"onmouseover",
+					"onmouseup",
+					"onchange",
+					'action',
+					'background',
+					'codebase',
+					'dynsrc',
+					'lowsrc',
+				);
+				
+				include_once($this->root_path."libraries/inputfilter/input.class.php");
+				$filter = new FilterInput($tag_blacklist, $attr_blacklist, 1, 1);
+				$strIn = $filter->clean($strIn);
+			}
+			return $strIn;
 		}
 		
 	}

--- a/core/data_handler/includes/modules/write/articles/pdh_w_articles.class.php
+++ b/core/data_handler/includes/modules/write/articles/pdh_w_articles.class.php
@@ -154,12 +154,7 @@ if(!class_exists('pdh_w_articles')) {
 				}
 			}
 			
-			if(!$this->user->check_auth('u_articles_script', false)){
-				include_once($this->root_path."libraries/inputfilter/input.class.php");
-				$filter = new FilterInput(TAG_BLACKLIST, ATTR_BLACKLIST, 1,1);
-				$strText = $filter->clean($strText);
-			}
-			
+			$strText = $this->filter_string($strText);
 			$strText = htmlspecialchars($strText);
 			
 			$objQuery = $this->db->prepare("INSERT INTO __articles :p")->set(array(
@@ -282,12 +277,7 @@ if(!class_exists('pdh_w_articles')) {
 				}
 			}
 			
-			if(!$this->user->check_auth('u_articles_script', false)){
-				include_once($this->root_path."libraries/inputfilter/input.class.php");
-				$filter = new FilterInput(TAG_BLACKLIST, ATTR_BLACKLIST, 1,1);
-				$strText = $filter->clean($strText);
-			}
-			
+			$strText = $this->filter_string($strText);
 			$strText = htmlspecialchars($strText);
 				
 			$arrOldData = $this->pdh->get('articles', 'data', array($id));
@@ -351,12 +341,7 @@ if(!class_exists('pdh_w_articles')) {
 				}
 			}
 			
-			if(!$this->user->check_auth('u_articles_script', false)){
-				include_once($this->root_path."libraries/inputfilter/input.class.php");
-				$filter = new FilterInput(TAG_BLACKLIST, ATTR_BLACKLIST, 1,1);
-				$strText = $filter->clean($strText);
-			}
-			
+			$strText = $this->filter_string($strText);
 			$strText = htmlspecialchars($strText);
 			
 			$arrOldData = $this->pdh->get('articles', 'data', array($id));
@@ -650,7 +635,60 @@ if(!class_exists('pdh_w_articles')) {
 			$strAlias = str_replace($a_satzzeichen, "", $strAlias);
 			return $strAlias;
 		}
-	
+		
+		private function filter_string($strIn){
+			if(!$this->user->check_auth('u_articles_script', false)){
+				
+				//Tag Blacklist for filtering article content
+				$tag_blacklist = array(
+					'applet',
+					'body',
+					'bgsound',
+					'base',
+					'basefont',
+					'frame',
+					'frameset',
+					'head',
+					'html',
+					'id',
+					'ilayer',
+					'layer',
+					'link',
+					'meta',
+					'name',
+					'script',
+					'title',
+					'xml',
+					'iframe',
+				);
+				
+				//Attribute Blacklist for filtering article content
+				$attr_blacklist = array(
+					'onclick',
+					"ondblclick",
+					"onkeydown",
+					"onkeypress",
+					"onkeyup",
+					"onmousedown",
+					"onmousemove",
+					"onmouseout",
+					"onmouseover",
+					"onmouseup",
+					"onchange",
+					'action',
+					'background',
+					'codebase',
+					'dynsrc',
+					'lowsrc',
+				);
+				
+				include_once($this->root_path."libraries/inputfilter/input.class.php");
+				$filter = new FilterInput($tag_blacklist, $attr_blacklist, 1, 1);
+				$strIn = $filter->clean($strIn);
+			}
+			return $strIn;
+		}
+
 	}
 }
 ?>


### PR DESCRIPTION
"Only scalar data can be contained in constants prior to PHP 5.6." [--> see php.net](https://php.net/manual/en/language.constants.syntax.php)

Examle of an error caused by this:
*  [error] 2074#2074: *132 FastCGI sent in stderr: "PHP message: PHP Warning:  Constants may only evaluate to scalar values in /var/www/eqdkp/core/constants.php on line 96