### PR TITLE
#1592 [calendar] attandee class-table rewritten

### DIFF
--- a/templates/base_template/calendar/viewcalraid_class.html
+++ b/templates/base_template/calendar/viewcalraid_class.html
@@ -1,106 +1,86 @@
 <!-- BEGIN raidstatus -->
-<div id="viewraidcal_colapse_{raidstatus.ID}" class="classdistribution center" >
-	<table class="table fullwidth">
-		<tr>
-			<td class="left w100p">
-				<table class="table fullwidth borderless">
-					<tr class="middle">
-						<th class="left" style="width:14px;">
-							<span class="toggle_button">&nbsp;</span>
-						</th>
-						<th colspan="{ATTENDEES_COLSPAN}" class="raidstatushead center">
-							<font class="status{raidstatus.ID}"> {raidstatus.NAME}</font>
-							({raidstatus.COUNT}/{raidstatus.MAXCOUNT}) <!-- IF raidstatus.COUNT_GUESTS -->[{raidstatus.COUNT_GUESTS}]<!-- ENDIF -->
-						</th>
-					</tr>
-				</table>
-			</td>
-		</tr>
-	</table>
-
-	<div class="toggle_container">
-		<table class="table fullwidth scrollable-x">
-			<tr>
-				<!-- BEGIN classes -->
-				<td class="middle" style="width: {COLUMN_WIDTH}%;">
-					<table class="table fullwidth borderless">
-						<tr>
-							<th class="class_{raidstatus.classes.ID} w100p"> {raidstatus.classes.CLASS_ICON} {raidstatus.classes.NAME} ({raidstatus.classes.COUNT}{raidstatus.classes.MAX})</th>
-						</tr>
-						<tr>
-							<td class="top">
-								<!-- BEGIN status -->
-								<div class="ui-state-hover table fullwidth noMobileTransform attendee_box<!-- IF raidstatus.classes.status.CHARISAWAY --> attendee_awaymode<!-- ENDIF -->" style="padding: 5px; margin-top: 4px;">
-									<div class="tr class_{raidstatus.classes.status.CLASSID}">
-										<div class="td" style="vertical-align:middle;">
-											<!-- IF IS_OPERATOR --><input class="status_confirm" type="checkbox" name="modstat_change[]" value="{raidstatus.classes.status.MEMBERID}" /><!-- ENDIF -->
-										</div>
-										<div class="td" style="vertical-align:middle;">
-											<span class="coretip-large" data-coretip='{raidstatus.classes.status.TOOLTIP}'>
-												<a class="normal <!-- IF COLORED_NAMESBYCLASS -->class_{raidstatus.classes.status.CLASSID}<!-- ENDIF -->" href="{raidstatus.classes.status.MEMBERLINK}" target="_blank">{raidstatus.classes.status.NAME}</a>
-												<!-- IF SHOW_RANDOMVALUE -->
-												<!-- IF raidstatus.classes.status.RANDOM gt 0 -->
-												[{raidstatus.classes.status.RANDOM}]
-												<!-- ENDIF -->
-												<!-- ENDIF -->
-											</span>
-										</div>
-										<div class="td buttonblock" style="float:right;vertical-align:middle;">
-											<!-- IF NOTEPERMISSION -->
-											<!-- IF raidstatus.classes.status.NOTE_PUBLIC -->
-											<i class="fa <!-- IF raidstatus.classes.status.ADMINNOTE -->fa-info-circle<!-- ELSE -->fa-comment<!-- ENDIF --> fa-lg coretip<!-- IF IS_OPERATOR --> hand<!-- ENDIF -->" data-coretip="{raidstatus.classes.status.NOTE_TT}"></i>
-											<!-- ENDIF -->
-											<!-- ENDIF -->
-											<!-- IF raidstatus.classes.status.RAIDGROUP_TT && SHOW_RAIDGROUPS -->
-											<i class="fa fa-users coretip" data-coretip="{raidstatus.classes.status.RAIDGROUP_TT}" style="color:{raidstatus.classes.status.GROUPCOLOR};"></i>
-											<!-- ENDIF -->
-											<!-- IF IS_OPERATOR -->
-											<span class="fa fa-cog fa-lg char_adminmenu hand" title="{L_raidevent_raid_changecharmenu}" data-character-id="member_{raidstatus.classes.status.MEMBERID}" data-status-id="{raidstatus.ID}"></span>
-											<div class="charadmintooltip nodisplay" id="member_{raidstatus.classes.status.MEMBERID}">
-												<div class="table bottommenu_chars_table">
-													<div class="tr">
-														<!-- IF raidstatus.classes.status.SHOW_CHARCHANGE -->
-														<div class="td absmiddle bottommenu_chars_icons">
-															<i class="fa fa-random fa-3x"></i>
-														</div>
-														<div class="td absmiddle">
-															{L_raidevent_raid_changecharmenu}<br/>
-															<input type="hidden" name="charchange_attendee" value="{raidstatus.classes.status.MEMBERID}" />
-															<input type="hidden" name="charchange_status" class="charchange_status" value="{raidstatus.ID}" />
-															{raidstatus.classes.status.DD_CHARS}{raidstatus.classes.status.DD_ROLES}
-															<button type="button" name="submit_charchange" value=""><i class="fa fa-check fa-lg"></i></button>
-														</div>
-														<!-- ENDIF -->
-														<div class="td absmiddle bottommenu_chars_icons">
-															<i class="fa fa-comment fa-3x"></i>
-														</div>
-														<div class="td absmiddle">
-															<span>
-																{L_raidevent_raid_changenotemenu}<br/>
-																<input type="hidden" name="notechange_attendee" value="{raidstatus.classes.status.MEMBERID}" />
-																<textarea name="notechange_note" class="bottommenu_chars_note" rows="1">{raidstatus.classes.status.NOTE}</textarea>
-																<button type="button" name="submit_notechange" value=""><i class="fa fa-check fa-lg"></i></button>
-															</span>
-														</div>
-													</div>
-												</div>
-											</div>
-											<!-- ENDIF -->
-										</div>
-									</div>
-								</div>
-								<!-- END status -->
-							</td>
-						</tr>
-					</table>
-				</td>
-			<!-- IF raidstatus.classes.BREAK -->
-			</tr><tr>
-			<!-- ENDIF -->
-			<!-- END classes -->
-			</tr>
-		</table>
+<div id="viewraidcal_colapse_{raidstatus.ID}" class="attendee_table">
+	<h4 class="state_header">
+		<span class="toggle_button">&nbsp;</span>
+		{raidstatus.NAME}
+		<span class="state_count">({raidstatus.COUNT}/{raidstatus.MAXCOUNT})</span>
+		<!-- IF raidstatus.COUNT_GUESTS --><span class="state_noguests">[{raidstatus.COUNT_GUESTS}]</span><!-- ENDIF -->
+	</h4>
+	
+	<div class="class_table toggle_container">
+		<!-- BEGIN classes -->
+		<div class="class_column" data-class-id="{raidstatus.classes.ID}" data-attendee-count="{raidstatus.classes.COUNT}">
+			<div class="class_header">
+				{raidstatus.classes.CLASS_ICON}
+				<span class="class_name class_{raidstatus.classes.ID}">{raidstatus.classes.NAME}</span>
+				<span class="attendee_count">({raidstatus.classes.COUNT}{raidstatus.classes.MAX})</span>
+			</div>
+			
+			<!-- BEGIN status -->
+			<div class="attendee_box">
+				<div class="attendee_select">
+					<!-- IF IS_OPERATOR -->
+					<input type="checkbox" name="modstat_change[]" value="{raidstatus.classes.status.MEMBERID}" />
+					<!-- ENDIF -->
+				</div>
+				
+				<div class="attendee_name">
+					<span class="coretip-large" data-coretip='{raidstatus.classes.status.TOOLTIP}'>
+						<a class="normal <!-- IF COLORED_NAMESBYCLASS -->class_{raidstatus.classes.status.CLASSID}<!-- ENDIF -->" href="{raidstatus.classes.status.MEMBERLINK}" target="_blank">{raidstatus.classes.status.NAME}</a>
+						<!-- IF SHOW_RANDOMVALUE -->
+						<!-- IF raidstatus.classes.status.RANDOM gt 0 -->
+						[{raidstatus.classes.status.RANDOM}]
+						<!-- ENDIF -->
+						<!-- ENDIF -->
+					</span>
+				</div>
+				
+				<div class="attendee_info">
+					<!-- IF NOTEPERMISSION -->
+					<!-- IF raidstatus.classes.status.NOTE_PUBLIC -->
+					<i class="fa <!-- IF raidstatus.classes.status.ADMINNOTE -->fa-info-circle<!-- ELSE -->fa-comment<!-- ENDIF --> fa-lg coretip<!-- IF IS_OPERATOR --> hand<!-- ENDIF -->" data-coretip="{raidstatus.classes.status.NOTE_TT}"></i>
+					<!-- ENDIF -->
+					<!-- ENDIF -->
+					
+					<!-- IF raidstatus.classes.status.RAIDGROUP_TT && SHOW_RAIDGROUPS -->
+					<i class="fa fa-users coretip" data-coretip="{raidstatus.classes.status.RAIDGROUP_TT}" style="color:{raidstatus.classes.status.GROUPCOLOR};"></i>
+					<!-- ENDIF -->
+					
+					<!-- IF IS_OPERATOR -->
+					<span class="fa fa-cog fa-lg char_adminmenu hand" title="{L_raidevent_raid_changecharmenu}" data-character-id="member_{raidstatus.classes.status.MEMBERID}" data-status-id="{raidstatus.ID}"></span>
+					<div class="charadmintooltip nodisplay" id="member_{raidstatus.classes.status.MEMBERID}">
+						<div class="bottommenu_chars_table">
+							<!-- IF raidstatus.classes.status.SHOW_CHARCHANGE -->
+							<div class="bottommenu_chars_icons">
+								<i class="fa fa-random fa-3x"></i>
+							</div>
+							<div class="bottommenu_chars_change">
+								{L_raidevent_raid_changecharmenu}<br/>
+								<input type="hidden" name="charchange_attendee" value="{raidstatus.classes.status.MEMBERID}" />
+								<input type="hidden" name="charchange_status" class="charchange_status" value="{raidstatus.ID}" />
+								{raidstatus.classes.status.DD_CHARS}{raidstatus.classes.status.DD_ROLES}
+								<button type="button" name="submit_charchange" value=""><i class="fa fa-check fa-lg"></i></button>
+							</div>
+							<!-- ENDIF -->
+							<div class="bottommenu_chars_icons">
+								<i class="fa fa-comment fa-3x"></i>
+							</div>
+							<div class="bottommenu_chars_change">
+								<span>
+									{L_raidevent_raid_changenotemenu}<br/>
+									<input type="hidden" name="notechange_attendee" value="{raidstatus.classes.status.MEMBERID}" />
+									<textarea name="notechange_note" class="bottommenu_chars_note" rows="1">{raidstatus.classes.status.NOTE}</textarea>
+									<button type="button" name="submit_notechange" value=""><i class="fa fa-check fa-lg"></i></button>
+								</span>
+							</div>
+						</div>
+					</div>
+					<!-- ENDIF -->
+				</div>
+			</div>
+			<!-- END status -->
+		</div>
+		<!-- END classes -->
 	</div>
 </div>
-<br />
- <!-- END raidstatus -->
+<!-- END raidstatus -->

--- a/templates/eqdkp_modern/eqdkp_modern.css
+++ b/templates/eqdkp_modern/eqdkp_modern.css
@@ -2395,6 +2395,9 @@ fieldset.settings.floatRight.raid input[type="text"]{
 	border-radius: 10px 10px 0px 0px;
 }
 .bottommenu_chars_table {
+	display: flex;
+	align-items: center;
+	flex-wrap: nowrap;
 	height: 70px;
 	width:100%;
 }
@@ -2403,10 +2406,14 @@ fieldset.settings.floatRight.raid input[type="text"]{
 	width:100%;
 }
 .bottommenu_chars_icons {
+	flex: 0 0 auto;
 	width:65px;
 }
 .bottommenu_admin_icons {
 	width:48px;
+}
+.bottommenu_chars_change {
+	flex:1 0 auto;
 }
 .bottommenu_chars_note {
 	width:60%;
@@ -2511,6 +2518,32 @@ a.attendee_Link:hover{
 .raidcal_warningbox table th {
 	background-color: #F2DEDE;
 	color: red;
+}
+
+.attendee_table {
+	// table header
+	.state_header	{ color:#000; font-size:13px; font-weight:bold; font-family:'Trebuchet MS',Arial,sans-serif; padding:10px 0px; background:#e8e8e8; border:1px solid #ccc; margin-bottom:2px; }
+	.toggle_button	{ float:left; margin:-1px 5px 0; }
+	.state_count	{ font-size:95%; font-weight:normal; margin-left:5px; letter-spacing:1px; }
+	.state_noguests	{ color:#777; font-size:90%; font-weight:normal; font-style:italic; }
+	
+	.class_table							{ display:flex; flex-wrap:wrap; justify-content:space-between; margin-bottom:5px; }
+	.class_column							{ display:flex; flex-direction:column; width:200px; margin-bottom:5px; white-space:nowrap; }
+	.class_column[data-attendee-count="0"]	{ opacity: .3; }
+	
+	// column header
+	.class_header					{ display:flex; justify-content:space-between; text-align:center; padding:2px 3px; background:#e8e8e8; border-bottom:1px solid #aaa; }
+	.class_name						{ font-weight:bold; }
+	.class_name[class*='class_']	{ text-shadow:1px 1px 0px rgba(0,0,0,.7); }
+	.attendee_count					{ font-size:9px; letter-spacing:1px; margin-top:auto; line-height:11px; }
+	
+	// attendee
+	.attendee_box						{ display:flex; padding:2px; margin:4px 4px 0; border:1px solid #4d4d4d; background: transparent linear-gradient(to bottom, #fff 0%, #cdcdcd 100%); color: #000; }
+	.attendee_select					{ flex:0 0 22px; }
+	.attendee_name, .attendee_name a	{ flex:2 1 100%; color: #000; overflow:hidden; text-overflow:ellipsis; }
+	.attendee_name a[class*='class_']	{ text-shadow:0 0 0 rgba(0,0,0,.7); }
+	.attendee_info						{ flex:1 0 0px; }
+	
 }
 
 /* calendar: raidevent view - Not signed in Members Bar */


### PR DESCRIPTION
ACHTUNG: Diese Änderungen betrifft aktuell nur die Klassen-verteilung.
Es fehlen die Änderungen

1. für die Rollen-verteilung
2. Ohne-verteilung
3. das bottommenu_admin_ *
4. das Leaderboard
5. die ACP Einstellung

.......
! Es müssen desweiteren geprüft werden ob alle JS trigger weiterhin funktionieren (@wallenium du kennst dein Zeug einfach besser)

! CSS: `.attandee_table` ist eventuell etwas blöd & unübersichtlich...
war Faulheit und es war für mich einfach leichter von meinem `Dev-Konstrukt -> richtiges CSS` zu übersetzen^^

Solltest du probleme haben die korrekte Struktur für die anderen Sachen herauszulesen, helf ich dir gerne und mach dir mal eine Beispieldatei, wo du nur das Gerüst hast.

Ggf. sollten die verwendeteten CSS Klassen überdacht werden (bin nicht so in Namensfindung)
