### PR TITLE
Revert "Fixed Usage of get_document_root()"

### DIFF
--- a/libraries/template/template.class.php
+++ b/libraries/template/template.class.php
@@ -1772,7 +1772,7 @@ class template extends gen_class {
 
 			$options = array();
 			$parser = new Less_Parser($options);
-			$parser->SetImportDirs([$this->env->get_document_root(true) => registry::get_const('server_path')]);
+			$parser->SetImportDirs([$this->env->get_document_root(false).registry::get_const('server_path') => registry::get_const('server_path')]);
 			$parser->ModifyVars($lessVars);
 			$parser->parse($strCSS);
 			$strCSS = $parser->getCss();


### PR DESCRIPTION
This reverts commit e6687752ea82eb1b13d33c1fb446e06590172dd1.

So Godmod, wie gewünscht den reverse PR von mir. Hab dir auch nochmal dazugehängt was, wie wo aussieht.

Default sind:  ` true, false` und der 2te Parameter kann nur true sein wenn ersterer true ist (dadurch auch die kurze Anzahl an möglichkeiten siehe die Tabellen).
Mein EQdkp Pfad ist:  `C:/xampp/htdocs/test/` ,.. so sollte auch bei allen 3 Seiten der Output aussehn.

### Seite: /index.php/
Funktionsparameter | Output
---|---
false, false | C:/xampp/htdocs
true, true | C:/xampp/htdocs/test/
(default) | C:/xampp/htdocs/test/

### Seite: /admin/manage_extensions.php
Funktionsparameter | Output
---|---
false, false | C:/xampp/htdocs
true, true | C:/xampp/htdocs/test/admin/
(default) | C:/xampp/htdocs/test/admin/

### Seite: /plugins/chat/admin/settings.php
Funktionsparameter | Output
---|---
false, false | C:/xampp/htdocs
true, true | C:/xampp/htdocs/test/plugins/chat/admin/
(default) | C:/xampp/htdocs/test/plugins/chat/admin/