### PR TITLE
correct use of `get_document_root()` at the less import dir

### DIFF
--- a/libraries/template/template.class.php
+++ b/libraries/template/template.class.php
@@ -1772,7 +1772,7 @@ class template extends gen_class {
 
 			$options = array();
 			$parser = new Less_Parser($options);
-			$parser->SetImportDirs([$this->env->get_document_root(true) => registry::get_const('server_path')]);
+			$parser->SetImportDirs([$this->env->get_document_root(true, true) => registry::get_const('server_path')]);
 			$parser->ModifyVars($lessVars);
 			$parser->parse($strCSS);
 			$strCSS = $parser->getCss();


### PR DESCRIPTION
`$this->server_path` spuckt halt den Pfad des Requests aus^^
Aber sonst läufts nun, `get_document_root()`, gibt mir den Server Document Root zurück, den Root des Seiten Requests und halt den des EQdkps...