### PR TITLE
Formvali 3

### DIFF
--- a/admin/manage_users.php
+++ b/admin/manage_users.php
@@ -993,6 +993,7 @@ class Manage_Users extends page_generic {
 		$this->form->lang_prefix = 'user_sett_';
 		$this->form->use_tabs = true;
 		$this->form->use_fieldsets = true;
+		$this->form->validate = true;
 
 		$settingsdata = user::get_settingsdata($user_id);
 

--- a/libraries/jquery/jquery.class.php
+++ b/libraries/jquery/jquery.class.php
@@ -936,13 +936,13 @@ if (!class_exists("jquery")) {
 				$(this).addClass("fv_checked");
 				if( $(".fv_checkit").find(".ui-tabs").length ){
 					var tabhighlight = { };
-					$(".fv_checkit input[required]").each(function( index, node ) {
+					$(".fv_checkit input[required], .fv_checkit input[pattern]").each(function( index, node ) {
 						tabs = $(this).parentsUntil(".fv_checkit .ui-tabs");
-						tabhighlight[tabs.attr("id")] = "valid";
+						tabhighlight[$(tabs[(tabs.length - 1)]).attr("id")] = "valid";
 					});
-					$(".fv_checkit input[required]:invalid").each(function( index, node ) {
+					$(".fv_checkit input[required]:invalid, .fv_checkit input[pattern]:invalid").each(function( index, node ) {
 						tabs = $(this).parentsUntil(".fv_checkit .ui-tabs");
-						tabhighlight[tabs.attr("id")] = "invalid";
+						tabhighlight[$(tabs[(tabs.length - 1)]).attr("id")] = "invalid";
 					});
 					$(this).find(".fv_hint_tab").each(function(){ $(this).remove(); });
 					for (var key in tabhighlight) {
@@ -958,7 +958,7 @@ if (!class_exists("jquery")) {
 				}
 
 				// the existing form validation
-				$(".fv_checkit input").each(function( index, node ) {
+				$(".fv_checkit input[required], .fv_checkit input[pattern]").each(function( index, node ) {
 					if($(this).is(":invalid")){
 						if(typeof $(this).data("fv-message") !== "undefined" && !$(this).next(".fv_msg").length){
 							$(this).after("<span class=\"fv_msg\">"+$(this).data("fv-message")+"</span>");

--- a/templates/eqdkpplus.css
+++ b/templates/eqdkpplus.css
@@ -377,14 +377,18 @@ i.small {
 }
 
 /* HTML5 form validation */
-.fv_checkit.fv_checked [required]:invalid {
+.fv_checkit.fv_checked [required]:invalid,
+.fv_checkit.fv_checked [pattern]:invalid {
 	border: 1px solid red !important;
 	box-shadow: none;
 }
-.fv_checkit [required] ~ .fv_msg {
+.fv_checkit [required] ~ .fv_msg,
+.fv_checkit [pattern] ~ .fv_msg {
 	display:none;
 }
-.fv_checkit [required]:invalid ~ .fv_msg, .errormessage {
+.fv_checkit [required]:invalid ~ .fv_msg,
+.fv_checkit [pattern]:invalid ~ .fv_msg,
+.errormessage {
 	display: inline-block;
 	position: relative;
 	margin-left: 10px;
@@ -394,7 +398,9 @@ i.small {
 	color: #a94442;
 	white-space: nowrap;
 }
-.fv_checkit [required]:invalid ~ .fv_msg:before, .errormessage::before {
+.fv_checkit [required]:invalid ~ .fv_msg:before,
+.fv_checkit [pattern]:invalid ~ .fv_msg:before,
+.errormessage::before {
 	content: '';
 	position: absolute;
 	right: 100%;
@@ -411,7 +417,7 @@ i.small {
 
 @supports (-webkit-appearance:none) {
 	.fv_checkit .ui-tabs .ui-tabs-panel[aria-hidden="true"] {
-		/*display: block !important;*/
+		/*display: block !important;  -- use it, if a browser like 'chrome' can't trigger/detect hidden elements && fix wrong height-calculation with top:-999em; */
 		opacity: 0;
 		z-index: -99999;
 		position: absolute;


### PR DESCRIPTION
Das sollte nun auch Inputs prüfen welche pattern drin haben aber kein required.

Die Kuriosität mit `tabhighlight[$(tabs[(tabs.length - 1)]).attr("id")] = "invalid";` sollte das Problem beheben wodurch die Tabs nicht korrekt erkannt wurden, da `.parentsUntil()` mehrere Elemente zurückwarf und dadurch JS ins straucheln kam.
Also nimmt er nun immer das zuletzt gefundene Element und wendet darauf `.attr('id')` an.

Die fehlende formvalidation auf admin/manage_users.php ist behoben.

Und bzg der `[required] & [pattern]` Geschichte wurde das CSS überarbeitet, sowie eine Notiz angehängt zum kürzlich entfernen `display:block`.