### PR TITLE
better position of selects in btn-ddm

### DIFF
--- a/core/core.class.php
+++ b/core/core.class.php
@@ -905,13 +905,6 @@ class core extends gen_class {
 				}
 			}
 
-			$this->tpl->add_js("
-				$('.btn-ddm li[data-type=\"select\"]').hover(function(){
-					var middle = -($(' > ul', this).outerHeight() / 2) + ($(this).height() / 2);
-					$(' > ul', this).css('top', middle +'px');
-				});
-			", 'docready');
-
 			return str_replace("<ul></ul>", "", $html);
 		}
 

--- a/templates/eqdkp_modern/eqdkp_modern.css
+++ b/templates/eqdkp_modern/eqdkp_modern.css
@@ -799,8 +799,9 @@ ul.adminmenu ul.sub-menu li:hover > .sub-menu-arrow:after {
 	display: none;
 	padding: 3px;
 	position: absolute;
-	top: -1.5px;
+	top: 50%;
 	left: 100%;
+	transform: translateY(-50%);
 	background: linear-gradient(to bottom, #fff 0%, #ededed 100%);
 	border: 1px solid #b7b7b7;
 	border-radius: 3px;


### PR DESCRIPTION
Remove unlucky Javascript Code for centering the inner selects of button dropdown menus.

**But** maybe we should remove the full code from core.class and add a new html lass, like hbutton, hmultiselect etc.
Don't know why i written it in the core.class at the time :/