### PR TITLE
Add the possibility to get an ical Feed for specific calendars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ core/notifications/whatsapp.notification.class.php
 templates/eqdkp_bf_v
 templates/eqdkp_bf
 templates/eqdkp_wow
+.vscode

--- a/exchange.php
+++ b/exchange.php
@@ -117,7 +117,9 @@ if(registry::register('input')->get('out') != ''){
 								$eventsfilter = 'appointments';
 							break;
 						}
-						$caleventids	= registry::register('plus_datahandler')->get('calendar_events', 'id_list', array($eventsfilter, registry::register('time')->createRepeatableEvents(registry::register('time')->time, -30)));
+						$calendars = registry::register('input')->get('calendars', '');
+						$calendarIds = $calendars ? explode(',', $calendars) : false;
+						$caleventids	= registry::register('plus_datahandler')->get('calendar_events', 'id_list', array($eventsfilter, registry::register('time')->createRepeatableEvents(registry::register('time')->time, -30), PHP_INT_MAX, $calendarIds));
 
 						if(is_array($caleventids) && count($caleventids) > 0){
 							foreach($caleventids as $calid){


### PR DESCRIPTION
I wrote an extention to the exchange.php to allow getting an ical feed that does not contain all calendars of the system. This enables to share events with external systems without these getting cluttered with unneeded events.