### PR TITLE
delete registrations after X days

### DIFF
--- a/core/cronjobs/pruneuserregistrations_crontask.class.php
+++ b/core/cronjobs/pruneuserregistrations_crontask.class.php
@@ -52,7 +52,7 @@ if ( !class_exists( "pruneuserregistrations_crontask" ) ) {
 				$intDays = 30;
 			}
 			
-			$objQuery = $this->db->query("SELECT * FROM __users WHERE user_email_confirmed = -1");
+			$objQuery = $this->db->prepare("SELECT * FROM __users WHERE user_email_confirmed = -1 AND timestampdiff(DAY, FROM_UNIXTIME(user_registered), now()) > ?")->execute($intDays);
 			$intCount = 0;
 			if($objQuery){
 				while($row = $objQuery->fetchAssoc()){


### PR DESCRIPTION
User registrations are deleted immediately with the current code wich leads to unwanted deletions.
I used the default values based on the registration type to delete registrations afer 30 days with admin activation and 14 days with user activation.